### PR TITLE
Added safety checks to Hider and Expression to prevent crashes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(headers
         include/Papyrus.h
         include/Expression.h
         include/Hider.h
+        include/NodeHider.h
 )
 
 set(sources
@@ -31,6 +32,7 @@ set(sources
         src/Papyrus.cpp
         src/Expression.cpp
         src/Hider.cpp
+        src/NodeHider.cpp
 
         ${CMAKE_CURRENT_BINARY_DIR}/version.rc)
 

--- a/include/Hider.h
+++ b/include/Hider.h
@@ -3,9 +3,29 @@
 
 namespace DeviousDevices
 {
-    std::vector<int> RebuildSlotMask(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, std::vector<int> a_slotusage, std::vector<int> a_slotfilter);
+    class DeviceHiderManager
+    {
+    public:
+        DeviceHiderManager(DeviceHiderManager &) = delete;
+        void operator=(const DeviceHiderManager &) = delete;
+        static DeviceHiderManager* GetSingleton();
+
+        void Setup();
+        std::vector<int> RebuildSlotMask(RE::Actor* a_actor, std::vector<int> a_slotfilter);
+        int FilterMask(RE::Actor* a_actor, int a_slotmask);
+        bool IsValidForHide(RE::TESObjectARMO* a_armor);
+    protected:
+        DeviceHiderManager(){}
+        ~DeviceHiderManager(){}
+        static DeviceHiderManager* _this;
+        RE::BGSKeyword* _kwnohide = nullptr;
+        RE::BGSKeyword* _kwlockable = nullptr;
+        RE::BGSKeyword* _kwplug = nullptr;
+        RE::BGSKeyword* _kwsos = nullptr;
+        std::vector<RE::BGSKeyword*> _hidekeywords;
+        std::vector<RE::BGSKeyword*> _nohidekeywords;
+    };
+
+    std::vector<int> RebuildSlotMask(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, std::vector<int> a_slotfilter);
     int FilterMask(PAPYRUSFUNCHANDLE,RE::Actor* a_actor, int a_slotmask);
-
-    bool _IsValidForHide(RE::TESObjectARMO* a_armor);
-
 }

--- a/include/NodeHider.h
+++ b/include/NodeHider.h
@@ -1,0 +1,24 @@
+#pragma once
+
+namespace DeviousDevices
+{
+    //for implementing this, I used https://github.com/ArranzCNL/ImprovedCameraSE-NG as reference which also hides arms using nodes
+    class NodeHider
+    {
+    public:
+        NodeHider(NodeHider &) = delete;
+        void operator=(const NodeHider &) = delete;
+        static NodeHider* GetSingleton();
+
+
+        void HideArms();
+        void ShowArms();
+        void Setup();
+    protected:
+        NodeHider(){}
+        ~NodeHider(){}
+
+        static NodeHider* _this;
+    };
+
+}

--- a/src/Expression.cpp
+++ b/src/Expression.cpp
@@ -8,7 +8,7 @@ namespace DeviousDevices
     }
 
     std::vector<float> GetExpression(PAPYRUSFUNCHANDLE, RE::Actor* a_actor)
-    {
+    {   
         return _GetExpression(a_actor);
     }
 
@@ -19,7 +19,9 @@ namespace DeviousDevices
 
     std::vector<float> FactionsToPreset(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, std::vector<RE::TESFaction*> a_factions, std::vector<int> a_defaults)
     {
-        std::vector<float> loc_preset(32,0.0);
+        if (a_actor == nullptr) return std::vector<float>(32,0.0f);
+
+        std::vector<float> loc_preset(32,0.0f);
 
         if (a_factions.size() > 0)
         {
@@ -42,6 +44,8 @@ namespace DeviousDevices
 
     std::vector<float> ApplyPhonemsFaction(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, std::vector<float> a_exp, std::vector<RE::TESFaction*> a_factions, std::vector<int> a_defaults)
     {
+        if (a_actor == nullptr) return a_exp;
+
         if (a_factions.size() > 0)
         {
             for(int i =0; i < a_factions.size();i++)
@@ -63,9 +67,13 @@ namespace DeviousDevices
 
     std::vector<float> _ApplyExpression(RE::Actor* a_actor, const std::vector<float> &a_expression, int a_control)
     {
-        if (a_expression.size() == 0U) return _GetExpression(a_actor);
+        if (a_actor == nullptr) return std::vector<float>();
 
         RE::BSFaceGenAnimationData* loc_expdata = a_actor->GetFaceGenAnimationData();
+
+        if (loc_expdata == nullptr) return std::vector<float>();
+
+        if (a_expression.size() == 0U) return _GetExpression(a_actor);
 
         RE::BSSpinLockGuard locker(loc_expdata->lock);
 
@@ -115,15 +123,17 @@ namespace DeviousDevices
                     break;
             }
         }
-
-
         return _GetExpression(a_actor);
     }
 
     std::vector<float> _GetExpression(RE::Actor* a_actor)
     {
+        if (a_actor == nullptr) return std::vector<float>(32,0.0f);
+
         RE::BSFaceGenAnimationData* loc_expdata = a_actor->GetFaceGenAnimationData();
         
+        if (loc_expdata == nullptr) return std::vector<float>(32,0.0f);
+
         std::vector<float> loc_res;
 
         for (int i = 0; i < 16; i++) loc_res.push_back(loc_expdata->phenomeKeyFrame.values[i]); 
@@ -134,7 +144,11 @@ namespace DeviousDevices
 
     void _ResetExpression(RE::Actor* a_actor, bool a_phonem, bool a_mods)
     {
+        if (a_actor == nullptr) return;
+        
         RE::BSFaceGenAnimationData* loc_expdata = a_actor->GetFaceGenAnimationData();
+
+        if (loc_expdata == nullptr) return;
 
         RE::BSSpinLockGuard locker(loc_expdata->lock);
 

--- a/src/Hider.cpp
+++ b/src/Hider.cpp
@@ -9,9 +9,12 @@ std::vector<int> DeviousDevices::RebuildSlotMask(PAPYRUSFUNCHANDLE, RE::Actor* a
     static RE::BGSKeyword* loc_nohidekeyword = nullptr;
     static std::vector<RE::BGSKeyword*> loc_nohidekeywordarr;
 
+    RE::TESDataHandler* loc_datahandler = RE::TESDataHandler::GetSingleton();
+    if (loc_datahandler == nullptr) return std::vector<int>();
+
     if (loc_nohidekeyword == nullptr)
     {
-        loc_nohidekeyword = static_cast<RE::BGSKeyword*>(RE::TESDataHandler::GetSingleton()->LookupForm(0x043F84,"Devious Devices - Integration.esm"));
+        loc_nohidekeyword = static_cast<RE::BGSKeyword*>(loc_datahandler->LookupForm(0x043F84,"Devious Devices - Integration.esm"));
         loc_nohidekeywordarr.push_back(loc_nohidekeyword);
     }
 
@@ -80,6 +83,9 @@ bool DeviousDevices::_IsValidForHide(RE::TESObjectARMO* a_armor)
     if (a_armor == nullptr) return false;
 
     static std::vector<RE::BGSKeyword*> loc_nohidekeywords;
+
+    RE::TESDataHandler* loc_datahandler = RE::TESDataHandler::GetSingleton();
+    if (loc_datahandler == nullptr) return false;
 
     //check lockable keyword
     static RE::BGSKeyword* loc_kwlockable = nullptr;

--- a/src/Hider.cpp
+++ b/src/Hider.cpp
@@ -1,24 +1,61 @@
 #include "Hider.h"
 
-std::vector<int> DeviousDevices::RebuildSlotMask(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, std::vector<int> a_slotusage, std::vector<int> a_slotfilter)
+DeviousDevices::DeviceHiderManager* DeviousDevices::DeviceHiderManager::_this = new DeviousDevices::DeviceHiderManager;
+
+void DeviousDevices::DeviceHiderManager::Setup()
+{
+    RE::TESDataHandler* loc_datahandler = RE::TESDataHandler::GetSingleton();
+
+    if (loc_datahandler == nullptr) return;
+
+    _hidekeywords.clear();
+
+    //check lockable keyword
+    if (_kwlockable == nullptr)
+    {
+        _kwlockable = static_cast<RE::BGSKeyword*>(loc_datahandler->LookupForm(0x003894,"Devious Devices - Assets.esm"));
+        if (_kwlockable != nullptr) _hidekeywords.push_back(_kwlockable);
+    }
+    //check plug keyword
+    if (_kwplug == nullptr)
+    {
+        _kwplug = static_cast<RE::BGSKeyword*>(loc_datahandler->LookupForm(0x003331,"Devious Devices - Assets.esm"));
+        if (_kwplug != nullptr) _hidekeywords.push_back(_kwplug);
+    }
+    //check SoS keyword
+    if (_kwsos == nullptr)
+    {
+        _kwsos = static_cast<RE::BGSKeyword*>(loc_datahandler->LookupForm(0x0012D9,"Schlongs of Skyrim - Core.esm"));
+        if (_kwsos != nullptr) _hidekeywords.push_back(_kwsos);
+    }
+    //check NoHide keyword
+    if (_kwnohide == nullptr)
+    {
+        _kwnohide = static_cast<RE::BGSKeyword*>(loc_datahandler->LookupForm(0x043F84,"Devious Devices - Integration.esm"));
+        if (_kwnohide != nullptr) _nohidekeywords.push_back(_kwnohide);
+    }
+}
+
+std::vector<int> DeviousDevices::RebuildSlotMask(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, std::vector<int> a_slotfilter)
+{
+    DeviceHiderManager* loc_hider = DeviceHiderManager::GetSingleton();
+    return loc_hider->RebuildSlotMask(a_actor,a_slotfilter);
+}
+
+int DeviousDevices::FilterMask(PAPYRUSFUNCHANDLE,RE::Actor* a_actor, int a_slotmask)
+{
+    DeviceHiderManager* loc_hider = DeviceHiderManager::GetSingleton();
+    return loc_hider->FilterMask(a_actor,a_slotmask);
+}
+
+DeviousDevices::DeviceHiderManager* DeviousDevices::DeviceHiderManager::GetSingleton()
+{
+    return _this;
+}
+
+std::vector<int> DeviousDevices::DeviceHiderManager::RebuildSlotMask(RE::Actor* a_actor, std::vector<int> a_slotfilter)
 {
     if (a_actor == nullptr) return std::vector<int>(); 
-
-    //get nohide keyword
-    //variables are made static to increase performance
-    static RE::BGSKeyword* loc_nohidekeyword = nullptr;
-    static std::vector<RE::BGSKeyword*> loc_nohidekeywordarr;
-
-    RE::TESDataHandler* loc_datahandler = RE::TESDataHandler::GetSingleton();
-    if (loc_datahandler == nullptr) return std::vector<int>();
-
-    if (loc_nohidekeyword == nullptr)
-    {
-        loc_nohidekeyword = static_cast<RE::BGSKeyword*>(loc_datahandler->LookupForm(0x043F84,"Devious Devices - Integration.esm"));
-        loc_nohidekeywordarr.push_back(loc_nohidekeyword);
-    }
-
-    if (loc_nohidekeyword == nullptr) return std::vector<int>();
 
     //result array
     //0-127 = SlotMaskUsage
@@ -28,20 +65,20 @@ std::vector<int> DeviousDevices::RebuildSlotMask(PAPYRUSFUNCHANDLE, RE::Actor* a
     for(uint32_t i1 = 0x00000001; i1 < 0x40000000; i1 <<= 1U)
     {
         //get armor from slot
-        RE::TESObjectARMO* loc_armor = a_actor->GetWornArmor(static_cast<RE::BIPED_MODEL::BipedObjectSlot>(i1));
+        const RE::TESObjectARMO* loc_armor = a_actor->GetWornArmor(static_cast<RE::BIPED_MODEL::BipedObjectSlot>(i1));
 
         //check if armor is not null (otherwise crash ;))
         //also check if armor have no no_hide keyword
-        if ((loc_armor != nullptr) && !loc_armor->HasKeywordInArray(loc_nohidekeywordarr,true))
+        if ((loc_armor != nullptr) && !loc_armor->HasKeywordInArray(_nohidekeywords,true))
         {
             //get slot mask
-            uint32_t loc_mask = static_cast<uint32_t>(loc_armor->GetSlotMask());
+            const uint32_t loc_mask = static_cast<uint32_t>(loc_armor->GetSlotMask());
 
             for(uint8_t i2 = 0; i2 < 31; i2++)
             {
                 if (loc_mask & (0x1U << i2))
                 {
-                    uint8_t loc_filterindx = i2*4;
+                    const uint8_t loc_filterindx = i2*4;
                     for(uint8_t i3 = loc_filterindx; i3 < (loc_filterindx+4); i3++)
                     {
                         if (a_slotfilter[i3] != 0)
@@ -58,7 +95,7 @@ std::vector<int> DeviousDevices::RebuildSlotMask(PAPYRUSFUNCHANDLE, RE::Actor* a
     return loc_res;
 }
 
-int DeviousDevices::FilterMask(PAPYRUSFUNCHANDLE,RE::Actor* a_actor, int a_slotmask)
+int DeviousDevices::DeviceHiderManager::FilterMask(RE::Actor* a_actor, int a_slotmask)
 {
     if (a_actor == nullptr) return 0x00000000;
 
@@ -69,7 +106,7 @@ int DeviousDevices::FilterMask(PAPYRUSFUNCHANDLE,RE::Actor* a_actor, int a_slotm
         {
             //get armor from slot
             RE::TESObjectARMO* loc_armor = a_actor->GetWornArmor(static_cast<RE::BIPED_MODEL::BipedObjectSlot>(i));
-            if ((loc_armor != nullptr) && (!_IsValidForHide(loc_armor)))
+            if ((loc_armor != nullptr) && (!IsValidForHide(loc_armor)))
             {
                 loc_res &= ~i;
             }
@@ -78,36 +115,8 @@ int DeviousDevices::FilterMask(PAPYRUSFUNCHANDLE,RE::Actor* a_actor, int a_slotm
     return loc_res;
 }
 
-bool DeviousDevices::_IsValidForHide(RE::TESObjectARMO* a_armor)
+bool DeviousDevices::DeviceHiderManager::IsValidForHide(RE::TESObjectARMO* a_armor)
 {
     if (a_armor == nullptr) return false;
-
-    static std::vector<RE::BGSKeyword*> loc_nohidekeywords;
-
-    RE::TESDataHandler* loc_datahandler = RE::TESDataHandler::GetSingleton();
-    if (loc_datahandler == nullptr) return false;
-
-    //check lockable keyword
-    static RE::BGSKeyword* loc_kwlockable = nullptr;
-    if (loc_kwlockable == nullptr)
-    {
-        loc_kwlockable = static_cast<RE::BGSKeyword*>(RE::TESDataHandler::GetSingleton()->LookupForm(0x003894,"Devious Devices - Assets.esm"));
-        if (loc_kwlockable != nullptr) loc_nohidekeywords.push_back(loc_kwlockable);
-    }
-    //check plug keyword
-    static RE::BGSKeyword* loc_kwplug = nullptr;
-    if (loc_kwplug == nullptr)
-    {
-        loc_kwplug = static_cast<RE::BGSKeyword*>(RE::TESDataHandler::GetSingleton()->LookupForm(0x003331,"Devious Devices - Assets.esm"));
-        if (loc_kwplug != nullptr) loc_nohidekeywords.push_back(loc_kwplug);
-    }
-    //check SoS keyword
-    static RE::BGSKeyword* loc_kwsos = nullptr;
-    if (loc_kwsos == nullptr)
-    {
-        loc_kwsos = static_cast<RE::BGSKeyword*>(RE::TESDataHandler::GetSingleton()->LookupForm(0x0012D9,"Schlongs of Skyrim - Core.esm"));
-        if (loc_kwsos != nullptr) loc_nohidekeywords.push_back(loc_kwsos);
-    }
-
-    return !a_armor->HasKeywordInArray(loc_nohidekeywords,false);
+    return !a_armor->HasKeywordInArray(_hidekeywords,false);
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,4 +1,6 @@
 #include "Papyrus.h"
+#include "Hider.h"
+#include "NodeHider.h"
 #include <stddef.h>
 
 using namespace RE::BSScript;
@@ -36,6 +38,43 @@ namespace {
             stl::report_and_fail("Failure to register Papyrus bindings.");
         }
     }
+
+    void InitializeMessaging() {
+        const auto g_messaging = GetMessagingInterface();
+        if (!g_messaging->RegisterListener([](MessagingInterface::Message* message) {
+                switch (message->type) {
+                    // Skyrim lifecycle events.
+                    case MessagingInterface::kPostLoad:  // Called after all plugins have finished running
+                        break;
+                    case MessagingInterface::kPostPostLoad:  // Called after all plugins have finished running
+                        break;
+                    case MessagingInterface::kInputLoaded:  // Called when all game data has been found.
+                        break;
+                    case MessagingInterface::kDataLoaded:  // All ESM/ESL/ESP plugins have loaded, main menu is now
+                                                           // active.
+                        DeviousDevices::DeviceHiderManager::GetSingleton()->Setup();
+                        // It is now safe to access form data.
+                        break;
+
+                    // Skyrim game events.
+                    case MessagingInterface::kSaveGame:  // The player has saved a game.
+                                                         // Data will be the save name.
+                    case MessagingInterface::kPostLoadGame:  // Player's selected save game has finished loading.
+                                                             // Data will be a boolean indicating whether the load was
+                                                             // successful.
+                        DeviousDevices::NodeHider::GetSingleton()->Setup();
+                        
+                        break;
+                    case MessagingInterface::kPreLoadGame:  // Player selected a game to load, but it hasn't loaded yet.
+                                                            // Data will be the name of the loaded save.
+                    case MessagingInterface::kNewGame:      // Player starts a new game from main menu.
+                    case MessagingInterface::kDeleteGame:  // The player deleted a saved game from within the load menu.
+                        break;
+                }
+            })) {
+            stl::report_and_fail("Unable to register message listener.");
+        }
+    }
 }
 
 SKSEPluginLoad(const LoadInterface* skse) {
@@ -47,6 +86,7 @@ SKSEPluginLoad(const LoadInterface* skse) {
 
     Init(skse);
     InitializePapyrus();
+    InitializeMessaging();
 
     log::info("{} has finished loading.", plugin->GetName());
     return true;

--- a/src/NodeHider.cpp
+++ b/src/NodeHider.cpp
@@ -1,0 +1,34 @@
+#include "NodeHider.h"
+
+DeviousDevices::NodeHider* DeviousDevices::NodeHider::_this = new DeviousDevices::NodeHider;
+
+DeviousDevices::NodeHider* DeviousDevices::NodeHider::GetSingleton()
+{
+    return _this;
+}
+
+void DeviousDevices::NodeHider::HideArms()
+{
+    RE::PlayerCharacter* loc_player = RE::PlayerCharacter::GetSingleton();
+    RE::NiNode* thirdpersonNode = loc_player->Get3D(0)->AsNode();
+    RE::NiNode* leftarmNode     = thirdpersonNode->GetObjectByName("NPC L UpperArm [LUar]")->AsNode();
+    RE::NiNode* rightarmNode    = thirdpersonNode->GetObjectByName("NPC R UpperArm [RUar]")->AsNode();
+
+    leftarmNode->local.scale  = 0.002f;
+    rightarmNode->local.scale = 0.002f;
+}
+
+void DeviousDevices::NodeHider::ShowArms()
+{
+    RE::PlayerCharacter* loc_player = RE::PlayerCharacter::GetSingleton();
+    RE::NiNode* thirdpersonNode = loc_player->Get3D(0)->AsNode();
+    RE::NiNode* leftarmNode     = thirdpersonNode->GetObjectByName("NPC L UpperArm [LUar]")->AsNode();
+    RE::NiNode* rightarmNode    = thirdpersonNode->GetObjectByName("NPC R UpperArm [RUar]")->AsNode();
+
+    leftarmNode->local.scale  = 1.000f;
+    rightarmNode->local.scale = 1.000f;
+}
+
+void DeviousDevices::NodeHider::Setup()
+{
+}


### PR DESCRIPTION
Also added experimental NoHider. This can be used to hide arms. Tested it and it looks promising, but issue is that implementing it will require collaboration of multiple people, as many parts of the framework would have to be updated (including most of the device which are both suits and heavy bondage). After it is implemented, it will allow to use any body armor while also using straitjackets/boxbinders. Best would also be to add some keyword which would signal that arms should be hidden (so some existing devices like straitjacket with hobble will still work). Tested it on boxbinder. See pics below

Pink catsuit + boxbinder (so clipping can be seen)
![ScreenShot_Astrix2982](https://github.com/ponzipyramid/DeviousDevicesNG/assets/103142567/13835ede-3b58-4041-9305-5c512dbfcc1d)
![ScreenShot_Astrix2983](https://github.com/ponzipyramid/DeviousDevicesNG/assets/103142567/059770df-e32c-4ca6-9791-975ebb45fc20)

No catsuit
![ScreenShot_Astrix2985](https://github.com/ponzipyramid/DeviousDevicesNG/assets/103142567/2f2d563b-f30d-4f07-ac2c-98a8493368de)
![ScreenShot_Astrix2984](https://github.com/ponzipyramid/DeviousDevicesNG/assets/103142567/28e23083-de36-4ae9-b68a-e8581dc478fc)

As you can see, arms and neck can be seen clipping. Should be easy to fix by adjusting mesh in bodyslide. Either way, I'm interested in what you think.

NOTE: I have also added the InitializeMessaging function from you testing branch, as I needed to setup the singletons. It is same implementation, so future merging should be hopefully without issue.