### PR TITLE
WIP: zad_isActorBusy and zadLibc.IsAnimating modifications

### DIFF
--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -2274,7 +2274,7 @@ EndFunction
 ;==================================================
 ; Is the actor animating through Sexlab, or DD?
 bool Function IsAnimating(actor akActor)
-	if (akActor.GetSitState() != 0) || akActor.IsOnMount()
+	if (akActor.GetSitState() != 0) ;|| akActor.IsOnMount()
 		return True
 	endif
 	return zad_isActorBusy(akActor) ;(akActor.IsInFaction(zadAnimatingFaction) || akActor.IsInFaction(Sexlab.AnimatingFaction))

--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -2277,7 +2277,7 @@ bool Function IsAnimating(actor akActor)
 	if (akActor.GetSitState() != 0) || akActor.IsOnMount()
 		return True
 	endif
-	return (akActor.IsInFaction(zadAnimatingFaction) || akActor.IsInFaction(Sexlab.AnimatingFaction))
+	return zad_isActorBusy(akActor) ;(akActor.IsInFaction(zadAnimatingFaction) || akActor.IsInFaction(Sexlab.AnimatingFaction))
 EndFunction
 
 ; Set DD's actor animating status.

--- a/dist/scripts/source/zadNativeFunctions.psc
+++ b/dist/scripts/source/zadNativeFunctions.psc
@@ -81,3 +81,4 @@ Armor[]  Function GetDevices(Actor akActor, int aiMode = 0, bool abWorn = False)
 
 ; Return worn device based on passed main keyword (set on equip script)
 Armor    Function GetWornDevice(Actor akActor, Keyword akKeyword, bool fuzzy = false)                   global native
+bool     Function zad_isActorBusy(Actor akActor)                                                        global native

--- a/include/LibFunctions.h
+++ b/include/LibFunctions.h
@@ -14,9 +14,9 @@ namespace DeviousDevices
         bool isActorBusy(RE::Actor* a_actor);
 
     private:
-        RE::BGSListForm* _busyFactionsListForm;
-        RE::TESFaction* _zadAnimatingFaction;
-        RE::TESFaction* _sexlabAnimatingFaction;
+        RE::BGSListForm* _busyFactionsListForm; // TODO: FLM/KID events for `SKSE::GetModCallbackEventSource()->AddEventSink`,
+                                                // and preload Faction forms in Setup and merge to `_busyFactions` (compatibility with FLM)
+        std::vector<RE::TESFaction*> _busyFactions;
     };
 
     std::vector<RE::TESObjectARMO*> GetDevices(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, int a_mode, bool a_worn);

--- a/include/LibFunctions.h
+++ b/include/LibFunctions.h
@@ -8,10 +8,18 @@ namespace DeviousDevices
     {
     SINGLETONHEADER(LibFunctions)
     public:
+        void Setup();
         std::vector<RE::TESObjectARMO*> GetDevices(RE::Actor* a_actor, int a_mode, bool a_worn);
         RE::TESObjectARMO* GetWornDevice(RE::Actor* a_actor, RE::BGSKeyword* a_kw, bool a_fuzzy);
+        bool isActorBusy(RE::Actor* a_actor);
+
+    private:
+        RE::BGSListForm* _busyFactionsListForm;
+        RE::TESFaction* _zadAnimatingFaction;
+        RE::TESFaction* _sexlabAnimatingFaction;
     };
 
     std::vector<RE::TESObjectARMO*> GetDevices(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, int a_mode, bool a_worn);
     RE::TESObjectARMO* GetWornDevice(PAPYRUSFUNCHANDLE, RE::Actor* a_actor, RE::BGSKeyword* a_kw, bool a_fuzzy);
+    bool zad_isActorBusy(PAPYRUSFUNCHANDLE, RE::Actor* a_actor);
 }

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -4,6 +4,7 @@
 #include "NodeHider.h"
 #include "UpdateHook.h"
 #include "DeviceReader.h"
+#include "LibFunctions.h"
 #include "Settings.h"
 #include <stddef.h>
 
@@ -76,6 +77,7 @@ namespace {
                                                              // Data will be a boolean indicating whether the load was
                                                              // successful.
                     case MessagingInterface::kNewGame: //also when player makes new game, as kPostLoadGame event is called too late on new game
+                        DeviousDevices::LibFunctions::GetSingleton()->Setup();
                         break;
                 }
             })) {

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -72,12 +72,12 @@ namespace {
                         DeviousDevices::DeviceHiderManager::GetSingleton()->Setup();
                         DeviousDevices::NodeHider::GetSingleton()->Setup();
                         DeviousDevices::UpdateHook::GetSingleton()->Setup();
+                        DeviousDevices::LibFunctions::GetSingleton()->Setup();
                         break;
                     case MessagingInterface::kPostLoadGame:  // Player's selected save game has finished loading.
                                                              // Data will be a boolean indicating whether the load was
                                                              // successful.
                     case MessagingInterface::kNewGame: //also when player makes new game, as kPostLoadGame event is called too late on new game
-                        DeviousDevices::LibFunctions::GetSingleton()->Setup();
                         break;
                 }
             })) {

--- a/src/Papyrus.cpp
+++ b/src/Papyrus.cpp
@@ -122,6 +122,7 @@ bool DeviousDevices::RegisterFunctions(IVirtualMachine* vm) {
     //LibFunctions
     REGISTERPAPYRUSFUNC(GetDevices, true);
     REGISTERPAPYRUSFUNC(GetWornDevice, true);
+    REGISTERPAPYRUSFUNC(zad_isActorBusy, true);
 
     #undef REGISTERPAPYRUSFUNC
     return true;


### PR DESCRIPTION
Not finished:
1. FormList Manipulator can modify FormList after initialize `DeviousDevices::LibFunctions::Setup()`. see 2 variants:
- 1) Read Formlist after `MessagingInterface::kPostLoadGame` (to read Formlist after all the modifications)
- 2) use `SKSE::GetModCallbackEventSource()->AddEventSink` - `FLM_SetupDone` 

(current, temporary, solution - fetch forms from FormList on each function call)

2. Do not know how reimplement `(akActor.GetSitState() != 0)`