### PR TITLE
Move soft dependency check to OnPlayerLoadGame

### DIFF
--- a/dist/scripts/source/zadConfig.psc
+++ b/dist/scripts/source/zadConfig.psc
@@ -349,25 +349,8 @@ Event OnConfigInit()
 	SetupEscapeDifficulties()
 	SetupBlindfolds()
 	SetupSoundDuration()
-	CheckForSoftDepends()
 	SlotMaskOIDS = new int[128]
 EndEvent
-
-Function CheckForSoftDepends()
-
-	If Game.IsPluginInstalled("OSLAroused.esp")
-		GotOSLA = True 		;OSL Aroused is here
-	Else
-		GotOSLA = False     ;not here
-	EndIf
-	
-	If Game.IsPluginInstalled("SexLab Inflation Framework.esp")
-		GotSLIF = True  ;SexLab Inflation Framework is here
-	Else
-		GotSLIF = False ;not here
-	EndIf
-
-EndFunction
 
 int Function GetVersion()
 	return 30 ; mcm menu version
@@ -530,7 +513,7 @@ Event OnPageReset(string page)
 			i += 1
 		EndWhile	
 	ElseIf page == "Debug"
-		SetCursorFillMode(TOP_TO_BOTTOM)								
+		SetCursorFillMode(TOP_TO_BOTTOM)
 		SetCursorPosition(1) ; Move cursor to top right position		
 		AddHeaderOption("Message Visibility Settings")
 		npcMessagesOID = AddToggleOption("Show NPC Messages", NpcMessages)

--- a/dist/scripts/source/zadPlayerScript.psc
+++ b/dist/scripts/source/zadPlayerScript.psc
@@ -59,6 +59,7 @@ endEvent
 Event OnPlayerLoadGame()
 	actor akActor = libs.PlayerRef
 	libs.SpellCastVibrateCooldown = 0.0
+	CheckForSoftDepends()
 	questScript.Maintenance()
 	cameraState.Maintenance()
 	libs.ResetDialogue()
@@ -73,7 +74,20 @@ Event OnPlayerLoadGame()
 	RegisterEvents()
 	InitGagSpeak(false)
 EndEvent
- 
+
+Function CheckForSoftDepends()
+	If Game.IsPluginInstalled("OSLAroused.esp")
+		libs.config.GotOSLA = True 		;OSL Aroused is here
+	Else
+		libs.config.GotOSLA = False     ;not here
+	EndIf
+
+	If Game.IsPluginInstalled("SexLab Inflation Framework.esp")
+		libs.config.GotSLIF = True  ;SexLab Inflation Framework is here
+	Else
+		libs.config.GotSLIF = False ;not here
+	EndIf
+EndFunction
  
 Event OnItemRemoved(Form akBaseItem, int aiItemCount, ObjectReference akItemReference, ObjectReference akDestContainer)
 	if akBaseItem == libs.SoulgemFilled


### PR DESCRIPTION
If I understand the code correctly, soft dependencies are checked only on first DD NG installation, never later.

Is there a reason why we cannot add those later, or why it is done like that?

This PR moves soft dependency check to OnPlayerLoadGame