### PR TITLE
Fix crash in DeviceReader.cpp

### DIFF
--- a/src/DeviceReader.cpp
+++ b/src/DeviceReader.cpp
@@ -39,7 +39,7 @@ RE::TESObjectARMO* DeviousDevices::DeviceReader::GetDeviceInventory(RE::TESObjec
         return (p.second.deviceRendered == a_renddevice);
     });
     
-    return loc_res->first;
+    return loc_res != _database.end() ? loc_res->first : nullptr;
 }
 
 void DeviceReader::LoadDDMods()


### PR DESCRIPTION
Details on Discord:
https://discord.com/channels/1132395152758018159/1132397798621454447/1195057294736634036

Example: call zadNativeFunctions.GetInventoryDevice() on zad_plugSoulgem02An_scriptInstance, or zad_gagStrapPanelOpen (both located in DD Assets)