### PR TITLE
AnimSwitchKeyword backwards compatibility conflict

### DIFF
--- a/dist/scripts/source/zadLibs.psc
+++ b/dist/scripts/source/zadLibs.psc
@@ -2314,7 +2314,7 @@ EndFunction
 String Function AnimSwitchKeyword( actor akActor, string idleName )
 	
 ;THERE USED TO BE SOMETHING BIG HERE, AND NOW OAR HANDLES THIS - krzp
-	If idleName == "Horny"
+	If idleName == "Horny" || idleName == "Horny01" || idleName == "Horny02" || idleName == "Horny03"
 			return "DDZazHornyA"
 	ElseIf idleName == "Edged"
 			return "DDZazHornyD"


### PR DESCRIPTION
Added Horny01, 02 and 03 to the possible calls as this was available in pre-NG Libs