### PR TITLE
Fixes build script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,7 +84,7 @@ jobs:
   build-papyrus:
     runs-on: windows-latest
     needs: check-changes
-    if: ${{ needs.check-changes.outputs.should_run >= 1 (github.event_name == 'workflow_dispatch' && always()) }}
+    if: ${{ needs.check-changes.outputs.should_run >= 1 || (github.event_name == 'workflow_dispatch' && always()) }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           git log --since="1 days ago" --name-only
           echo "should_run=$(git log --since="1 days ago" --name-only | grep "" -c)" >> "$GITHUB_OUTPUT"
       - name: Check if it's a fortnite job
-        if: github.event.schedule == "37 21 1,16 * *"
+        if: github.event.schedule == '37 21 1,16 * *'
         id: battle_pass
         shell: bash
         run: echo "should_run=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: "37 21 * * *"
+    - cron: "37 21 1,16 * *"
   workflow_dispatch:
     inputs:
       releaseNightly:
@@ -23,8 +24,29 @@ env:
   PROJECT_NAME: DDNG
 
 jobs:
+  check-changes:
+    name: Check for recent changes
+    if: ${{ github.event_name != 'workflow_dispatch' }}
+    runs-on: ubuntu-latest
+    outputs: 
+      should_run: ${{ steps.should_run_daily.outputs.should_run || steps.battle_pass.outputs.should_run }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check for changes last 24 hours
+        id: should_run_daily
+        shell: bash
+        run: |
+          git log --since="1 days ago" --name-only
+          echo "should_run=$(git log --since="1 days ago" --name-only | grep "" -c)" >> "$GITHUB_OUTPUT"
+      - name: Check if it's a fortnite job
+        if: github.event.schedule == "37 21 1,16 * *"
+        id: battle_pass
+        shell: bash
+        run: echo "should_run=true" >> "$GITHUB_OUTPUT"
   build-skse:
     runs-on: windows-latest
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.should_run >= 1 || (github.event_name == 'workflow_dispatch' && always()) }}
 
     steps:
     - uses: actions/checkout@v4
@@ -61,6 +83,8 @@ jobs:
 
   build-papyrus:
     runs-on: windows-latest
+    needs: check-changes
+    if: ${{ needs.check-changes.outputs.should_run >= 1 (github.event_name == 'workflow_dispatch' && always()) }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,13 +37,13 @@ jobs:
       uses: lukka/run-cmake@v10
       with:
         cmakeListsTxtPath: '${{ github.workspace }}/CMakeLists.txt'
-        configurePreset: build-debug-msvc
+        configurePreset: build-release-msvc
         configurePresetAdditionalArgs: "['-DCMAKE_TOOLCHAIN_FILE:STRING=C:/vcpkg/scripts/buildsystems/vcpkg.cmake']"
-        buildPreset: debug-msvc
+        buildPreset: release-msvc
 
     - name: Move binaries
       run: |
-        cd ${{github.workspace}}/build/debug-msvc
+        cd ${{github.workspace}}/build/release-msvc
         mkdir temp
         cd temp
         move ../DeviousDevices.dll
@@ -55,7 +55,7 @@ jobs:
         # Artifact name
         name: ${{ env.PROJECT_NAME }}-DLL
         # A file, directory or wildcard pattern that describes what to upload
-        path: build/debug-msvc/temp
+        path: build/release-msvc/temp
         # The desired behavior if no files are found using the provided path.
         retention-days: 90
 
@@ -158,7 +158,7 @@ jobs:
           release_name: Nightly Release ${{ steps.date_pretty.outputs.time }}
           body: Nightly release. Alpha build - be wary of bugs. Must be installed manually.
           keep_num: 2
-          keep_tags: true
+          keep_tags: false
 
       - name: Upload Release Asset
         env:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/79e8b43c-6491-4aa3-ad53-2625d6a0101c)

The previous version (built as debug) worked on my end. This change to building as release (suggested by @IHateMyKite) should make it work more consistently for other people.

I'd like to send the artifact out to people who experienced the issue to see if they can now run it before merging this PR.

This PR also forces the build script to ensure that there are changes in the repository before running a nightly.

EDIT: I think it works for IHMK so I'll assume it works for everyone

