### PR TITLE
Reworked API again

### DIFF
--- a/include/API.h
+++ b/include/API.h
@@ -24,8 +24,7 @@
 * Do not forget to include this source file to your project!
 */
 
-#define DD_APITYPEKEY static_cast<uint32_t>(0x0000DDDD)
-#define DD_APIVERSION 1U
+#define DD_APIVERSION 2U
 
 namespace DeviousDevicesAPI
 {
@@ -147,19 +146,18 @@ namespace DeviousDevicesAPI
     inline bool LoadAPI()
     {
         if (g_API != nullptr) return true;
-        SKSE::GetMessagingInterface()->Dispatch(DD_APITYPEKEY,(void*)&g_API,sizeof(void*),NULL);
-        if (g_API)
+        HINSTANCE dllHandle = LoadLibrary(TEXT("DeviousDevices.dll"));
+        if (dllHandle != NULL)
         {
-            //API succesfully received!
-            if (g_API->GetVersion() != DD_APIVERSION)
+            FARPROC pGetAPI = GetProcAddress(HMODULE (dllHandle),"GetAPI");
+            if (pGetAPI != NULL) 
             {
-                //API version is old. DO NOT USE!!!!
-                return false;
-            }
-            else
-            {
-                //Use API. You can save it to some static variable or to stack.
+                g_API = ((DeviousDevicesAPI*(* )(void))(pGetAPI))();
                 return true;
+            }
+            else 
+            {
+                return false;
             }
         }
         return false;

--- a/include/API.h
+++ b/include/API.h
@@ -152,8 +152,18 @@ namespace DeviousDevicesAPI
             FARPROC pGetAPI = GetProcAddress(HMODULE (dllHandle),"GetAPI");
             if (pGetAPI != NULL) 
             {
-                g_API = ((DeviousDevicesAPI*(* )(void))(pGetAPI))();
-                return true;
+                auto loc_api = ((DeviousDevicesAPI*(* )(void))(pGetAPI))();
+
+                if (loc_api != nullptr && (loc_api->GetVersion() == DD_APIVERSION))
+                {
+                    g_API = loc_api;
+                    return true;
+                }
+                else
+                {
+                    // API version is old. Update your API!!
+                    return false;
+                }
             }
             else 
             {

--- a/include/Config.h
+++ b/include/Config.h
@@ -4,6 +4,7 @@
 #include <boost/property_tree/ini_parser.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/lexical_cast.hpp>
+#include "Utils.h"
 
 namespace DeviousDevices
 {
@@ -23,6 +24,7 @@ namespace DeviousDevices
         bool _loaded = false;
         boost::property_tree::ptree _config;
         mutable std::unordered_map<std::string,void*> _catche;
+        mutable Spinlock _lock;
         std::vector<std::string> GetArrayRaw(std::string a_name, bool a_tolower, std::string a_sep = ",") const;
         bool _LogDisable = false;
     };

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -62,6 +62,7 @@ std::vector<std::string> ConfigManager::GetArrayRaw(std::string a_name, bool a_t
 template<typename T>
 T ConfigManager::GetVariable(std::string a_name, T a_def) const
 {
+    UniqueLock lock(_lock);
     if (!_loaded) return a_def;
 
     void* loc_cres = _catche[a_name];
@@ -86,6 +87,7 @@ T ConfigManager::GetVariable(std::string a_name, T a_def) const
 template<typename T>
 std::vector<T> ConfigManager::GetArray(std::string a_name, std::string a_sep) const
 {
+    UniqueLock lock(_lock);
     if (!_loaded) return std::vector<T>();
 
     void* loc_cres = _catche[a_name];
@@ -117,6 +119,7 @@ std::vector<T> ConfigManager::GetArray(std::string a_name, std::string a_sep) co
 
 std::vector<std::string> ConfigManager::GetArrayText(std::string a_name, bool a_lowercase, std::string a_sep) const
 {
+    UniqueLock lock(_lock);
     if (!_loaded) return std::vector<std::string>();
 
     void* loc_cres = _catche[a_name];


### PR DESCRIPTION
- Reworked API to no longer use SKSE events. Why ? Because its unreliable piece of junk that should not even work. Good ol reliable extern is better. Some other popular mods also use extern for sending API, so I dont see issue. Only the LoadAPI functions is changed for other requesting mods. Implementation is the same, so if some other mods use API, they only need to update the API source file, and nothing else
- Added SpinLocks to Config class, to increase stability in case the Config variable is fetched from other thread