### PR TITLE
FixedForceWalk effect not working correctl. Other fixes

### DIFF
--- a/include/HooksVirtual.h
+++ b/include/HooksVirtual.h
@@ -8,10 +8,14 @@ namespace DeviousDevices
     public:
         void Setup();
         static void ProcessButton(RE::MovementHandler* a_this, RE::ButtonEvent* a_event, RE::PlayerControlsData* a_data);
+        static void ProcessThumbstick(RE::MovementHandler* a_this, RE::ThumbstickEvent* a_event, RE::PlayerControlsData* a_data);
+        static void DrawWeaponMagicHands(RE::PlayerCharacter* a_this, bool a_draw);
 
     private:
         bool _init = false;
     private:
         inline static REL::Relocation<decltype(ProcessButton)>      ProcessButton_old;
+        inline static REL::Relocation<decltype(ProcessThumbstick)>  ProcessThumbstick_old;
+        inline static REL::Relocation<decltype(DrawWeaponMagicHands)>  DrawWeaponMagicHands_old;
     };
 }

--- a/include/LibFunctions.h
+++ b/include/LibFunctions.h
@@ -74,7 +74,9 @@ namespace DeviousDevices
         bool IsBound(RE::Actor* a_actor) const;
         BondageState GetBondageState(RE::Actor* a_actor) const;
         bool WornHasKeyword(RE::Actor* a_actor, RE::BGSKeyword* a_kw) const;
+        bool WornHasKeywordAll(RE::Actor* a_actor, RE::BGSKeyword* a_kw) const;
         bool WornHasKeyword(RE::Actor* a_actor, std::string a_kw) const;
+        bool WornHasKeywordAll(RE::Actor* a_actor, std::string a_kw) const;
         RE::TESObjectARMO* GetWornArmor(RE::Actor* a_actor,int a_mask) const;
         // Return first armor with passed keyword string
         RE::TESObjectARMO* GetWornArmor(RE::Actor* a_actor,const std::string& a_kw) const;

--- a/src/HooksVirtual.cpp
+++ b/src/HooksVirtual.cpp
@@ -1,4 +1,5 @@
 #include "HooksVirtual.h"
+#include "HooksVirtual.h"
 #include "LibFunctions.h"
 
 SINGLETONBODY(DeviousDevices::HooksVirtual)
@@ -10,38 +11,86 @@ void DeviousDevices::HooksVirtual::Setup()
         // Vtable of MovementHandler
         REL::Relocation<std::uintptr_t> vtbl_MovementHandler{RELOCATION_ID(263056, 208715).address()};
         ProcessButton_old = vtbl_MovementHandler.write_vfunc(0x04, ProcessButton);
+        ProcessThumbstick_old = vtbl_MovementHandler.write_vfunc(0x02, ProcessThumbstick);
+
+        REL::Relocation<std::uintptr_t> vtbl_player{RE::PlayerCharacter::VTABLE[0]};
+        DrawWeaponMagicHands_old = vtbl_player.write_vfunc(REL::Module::GetRuntime() != REL::Module::Runtime::VR ? 0x0A6 : 0x0A8, DrawWeaponMagicHands);
+
         _init = true;
     }
 }
 
 void DeviousDevices::HooksVirtual::ProcessButton(RE::MovementHandler* a_this, RE::ButtonEvent* a_event, RE::PlayerControlsData* a_data)
 {
-    static bool loc_applied = false;
-
     ProcessButton_old(a_this,a_event,a_data);
 
-    static bool loc_running = false;
-    if (!loc_applied)
-    {
-        loc_running = a_data->running;
-    }
+    // calculate amplitude
+    const float loc_ampl = a_data->moveInputVec.Length();
 
-    static auto loc_kwds = ConfigManager::GetSingleton()->GetArrayText("Movement.asForceWalkKeywords",false);
-    
-    for (auto&& it :loc_kwds)
+    static const float loc_maxspeed = ConfigManager::GetSingleton()->GetVariable<float>("Movement.afMaxSpeedMult",0.15f);
+
+    if (loc_ampl > loc_maxspeed)
     {
-        if (LibFunctions::GetSingleton()->WornHasKeyword(RE::PlayerCharacter::GetSingleton(),it))
+        static auto loc_kwds = ConfigManager::GetSingleton()->GetArrayText("Movement.asForceWalkKeywords",false);
+    
+        for (auto&& it :loc_kwds)
         {
-            a_data->running = false;
-            loc_applied = true;
-            return;
+            if (LibFunctions::GetSingleton()->WornHasKeywordAll(RE::PlayerCharacter::GetSingleton(),it))
+            {
+                // recalculate vector, so the direction of pointing is same, but the amplitude is reduced
+                a_data->moveInputVec.x = (a_data->moveInputVec.x)*loc_maxspeed;
+                a_data->moveInputVec.y = (a_data->moveInputVec.y)*loc_maxspeed;
+                return;
+            }
         }
     }
+}
 
-    // restore original value
-    if (loc_applied)
+void DeviousDevices::HooksVirtual::ProcessThumbstick(RE::MovementHandler* a_this, RE::ThumbstickEvent* a_event, RE::PlayerControlsData* a_data)
+{
+    ProcessThumbstick_old(a_this,a_event,a_data);
+
+    if (a_event->GetIDCode() != 11)
     {
-        loc_applied = false;
-        a_data->running = loc_running;
+        // This is not left analogue stick. Exit
+        return;
     }
+
+    // calculate amplitude
+    const float loc_ampl = a_data->moveInputVec.Length();
+
+    static const float loc_maxspeed = ConfigManager::GetSingleton()->GetVariable<float>("Movement.afMaxSpeedMult",0.15f);
+
+    if (loc_ampl > loc_maxspeed)
+    {
+        static auto loc_kwds = ConfigManager::GetSingleton()->GetArrayText("Movement.asForceWalkKeywords",false);
+    
+        for (auto&& it :loc_kwds)
+        {
+            if (LibFunctions::GetSingleton()->WornHasKeywordAll(RE::PlayerCharacter::GetSingleton(),it))
+            {
+                // recalculate vector, so the direction of pointing is same, but the amplitude is reduced
+                a_data->moveInputVec.x = (a_data->moveInputVec.x)*loc_maxspeed;
+                a_data->moveInputVec.y = (a_data->moveInputVec.y)*loc_maxspeed;
+                return;
+            }
+        }
+    }
+}
+
+void DeviousDevices::HooksVirtual::DrawWeaponMagicHands(RE::PlayerCharacter* a_this, bool a_draw)
+{
+    if (a_draw)
+    {
+        static auto loc_kwds = ConfigManager::GetSingleton()->GetArrayText("Movement.asDisableCombatKeywords",false);
+    
+        for (auto&& it :loc_kwds)
+        {
+            if (LibFunctions::GetSingleton()->WornHasKeywordAll(RE::PlayerCharacter::GetSingleton(),it))
+            {
+                return;
+            }
+        }
+    }
+    DrawWeaponMagicHands_old(a_this,a_draw);
 }

--- a/src/LibFunctions.cpp.bak
+++ b/src/LibFunctions.cpp.bak
@@ -1,4 +1,5 @@
 #include "LibFunctions.h"
+#include "LibFunctions.h"
 #include "InventoryFilter.h"
 
 SINGLETONBODY(DeviousDevices::LibFunctions)


### PR DESCRIPTION
- Fixed ForceWalk effect not correctly working for users who use controllers. Becasue of that this system is now reworked to essentiely work same for keyboard and controller. The speed multiplier can be edited in ini file. Also, the plugin will also check if armor enchant effects doesnt hava that keyword too. This way this change should be also compatible with devices which does not have the force walk keyword, but have the force walk magic effect
- Added ini setting for keywords which will prevent combat when worn by player. Currently only contains Pet Suit keyword
- Merged in the PAR fix by Frayed